### PR TITLE
feat: Create User Profiler Agent

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -90,6 +90,19 @@ The system employs a multi-agent architecture built on the AutoGen framework, ut
 -   **Message Passing**: Communication between agents.
 -   **Websockets**: Communication with Backend
 
+#### Data Model Management
+
+The project's data model is defined in `data_model/data_model.yaml`. The pydantic models in `backend/models/data_models.py` are generated from this file using `linkml`.
+
+To update the data models, you need to:
+
+1.  Modify the `data_model/data_model.yaml` file.
+2.  Run the following command to regenerate the pydantic models:
+
+```bash
+linkml-generate-pydantic data_model/data_model.yaml > backend/models/data_models.py
+```
+
 ### File Structure
 
 ```
@@ -255,6 +268,7 @@ The frontend will be available at `http://localhost:5173` by default and will co
 ✅ **RequirementsAnalystAgent**: Requirements gathering, analysis, and validation
 ✅ **ChangeDetectorAgent**: Change monitoring and management
 ✅ **TechnicalWriterAgent**: Generation and management of technical documentation
+✅ **UserProfilerAgent**: User profiling and knowledge assessment
 
 ### Implemented Features
 
@@ -299,6 +313,11 @@ The frontend will be available at `http://localhost:5173` by default and will co
 -   `template management` - Manage templates
 -   `export document` - Export in different formats
 -   `organize documents` - Organize documents
+
+#### User Profiler
+
+-   `start profiling` - Start the user profiling process
+-   `save profile` - Save the user profile
 
 ## Testing Strategy
 

--- a/backend/agents/factory.py
+++ b/backend/agents/factory.py
@@ -19,6 +19,7 @@ from .quality_agent import QualityAgent
 from .human_agent import HumanAgent
 from .project_management_agent import ProjectManagementAgent
 from .user_stories_agent import UserStoriesAgent
+from .user_profiler_agent import UserProfilerAgent
 from .user_agent import UserAgent
 from .tools import (
     TRIAGE_AGENT_TOPIC_TYPE,
@@ -28,6 +29,7 @@ from .tools import (
     HUMAN_AGENT_TOPIC_TYPE,
     PROJECT_MANAGEMENT_AGENT_TOPIC_TYPE,
     USER_STORIES_AGENT_TOPIC_TYPE,
+    USER_PROFILER_AGENT_TOPIC_TYPE,
     USER_TOPIC_TYPE,
 )
 
@@ -79,6 +81,9 @@ class AgentFactory:
         # Register the user stories agent
         self.registered_agents[USER_STORIES_AGENT_TOPIC_TYPE] = await self._register_user_stories_agent()
         
+        # Register the user profiler agent
+        self.registered_agents[USER_PROFILER_AGENT_TOPIC_TYPE] = await self._register_user_profiler_agent()
+
         # Register the human agent
         self.registered_agents[HUMAN_AGENT_TOPIC_TYPE] = await self._register_human_agent()
         
@@ -142,6 +147,14 @@ class AgentFactory:
             self.runtime,
             type=USER_STORIES_AGENT_TOPIC_TYPE,
             factory=lambda: UserStoriesAgent(self.model_client),
+        )
+
+    async def _register_user_profiler_agent(self):
+        """Register the user profiler agent."""
+        return await AIAgent.register(
+            self.runtime,
+            type=USER_PROFILER_AGENT_TOPIC_TYPE,
+            factory=lambda: UserProfilerAgent(self.model_client),
         )
     
     async def _register_human_agent(self):

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -38,6 +38,7 @@ QUALITY_AGENT_TOPIC_TYPE = "quality_agent"
 HUMAN_AGENT_TOPIC_TYPE = "human_agent"
 PROJECT_MANAGEMENT_AGENT_TOPIC_TYPE = "project_management_agent"
 USER_STORIES_AGENT_TOPIC_TYPE = "user_stories_agent"
+USER_PROFILER_AGENT_TOPIC_TYPE = "user_profiler_agent"
 USER_TOPIC_TYPE = "user"
 
 
@@ -75,6 +76,11 @@ async def transfer_to_project_management_agent() -> str:
 async def transfer_to_user_stories_agent() -> str:
     """Transfer control to the user stories gathering agent."""
     return USER_STORIES_AGENT_TOPIC_TYPE
+
+
+async def transfer_to_user_profiler_agent() -> str:
+    """Transfer control to the user profiler agent."""
+    return USER_PROFILER_AGENT_TOPIC_TYPE
 
 
 # Tool functions for project management tasks
@@ -492,4 +498,9 @@ create_uuid_tool = FunctionTool(
 transfer_to_user_stories_tool = FunctionTool(
     transfer_to_user_stories_agent,
     description="Only call this if explicitly asked to generate user stories or unpack requirements into detailed user stories with acceptance criteria.",
+)
+
+transfer_to_user_profiler_tool = FunctionTool(
+    transfer_to_user_profiler_agent,
+    description="Only call this if explicitly asked to create a user profile.",
 )

--- a/backend/agents/triage_agent.py
+++ b/backend/agents/triage_agent.py
@@ -17,6 +17,7 @@ from .tools import (
     transfer_to_quality_tool,
     transfer_to_project_management_tool,
     transfer_to_user_stories_tool,
+    transfer_to_user_profiler_tool,
     escalate_to_human_tool,
 )
 
@@ -48,6 +49,7 @@ class TriageAgent(AIAgent):
             "- Execution Agent: For task execution and project management\n"
             "- Quality Agent: For quality assurance and project reviews\n"
             "- User Stories Agent: For generating comprehensive user stories with EARS notation acceptance criteria\n"
+            "- User Profiler Agent: For understanding the user's capabilities and knowledge\n"
             "- Human Agent: For complex requests requiring human intervention\n\n"
             "Always be helpful and professional. Route users to the most appropriate agent."
         )
@@ -58,6 +60,7 @@ class TriageAgent(AIAgent):
             transfer_to_quality_tool,
             transfer_to_project_management_tool,
             transfer_to_user_stories_tool,
+            transfer_to_user_profiler_tool,
             escalate_to_human_tool,
         ]
         

--- a/backend/agents/user_profiler_agent.py
+++ b/backend/agents/user_profiler_agent.py
@@ -1,0 +1,75 @@
+"""
+User Profiler Agent for the handoffs pattern.
+
+This agent is responsible for understanding the user's capabilities and knowledge
+to better tune other agents' tone and questions based on its profile.
+"""
+
+import json
+
+from autogen_core.models import SystemMessage
+from autogen_core.tools import Tool
+
+
+from models.data_models import UserProfiler
+
+from base.AIAgent import AIAgent
+from .tools import (
+    USER_PROFILER_AGENT_TOPIC_TYPE,
+    USER_TOPIC_TYPE,
+    retrieve_project_data_tool,
+    save_project_data_tool,
+    transfer_back_to_triage_tool,
+    UUIDEncoder,
+)
+
+class UserProfilerAgent(AIAgent):
+    """
+    User profiler agent responsible for understanding the user's capabilities and knowledge.
+
+    This agent specializes in user profiling activities including:
+    - Asking the user about their role, experience, skills, and expectations
+    - Saving the user profile to the project's storage
+    """
+
+    def __init__(self, model_client, tools: list[Tool] = None):
+        """
+        Initialize the UserProfilerAgent.
+
+        Args:
+            model_client: The LLM client for processing requests
+            tools: Additional tools beyond the standard user profiler tools
+        """
+        system_message = SystemMessage(
+            content="You are a User Profiler agent. Your role is to:\n\n"
+            "1. Understand the user's capabilities and knowledge to better tune other agents' tone and questions based on its profile.\n"
+            "2. Ask the user about their role on the project, their experience on past similar projects, skills, and expectations.\n"
+            "3. Use the save_project_data_tool to save the user profile to the project's storage.\n"
+            "4. Transfer back to triage when the user profile is complete.\n\n"
+            "## RULES\n"
+            "1. Be friendly and conversational.\n"
+            "2. Ask one question at a time.\n"
+            "3. Start by asking the user about their role in the project.\n"
+            "4. Then, ask about their experience with similar projects.\n"
+            "5. Then, ask about their skills.\n"
+            "6. Finally, ask about their expectations.\n"
+            "7. When the user profile is complete, ask the user if they would like to save the profile.\n"
+            "8. If the user would like to save the profile, use the save_project_data_tool to save the data.\n"
+            "9. If the user would not like to save the profile, use the transfer_back_to_triage_tool to transfer back to the triage agent.\n"
+            "10. User profile data schema is defined as follows: '" + json.dumps(UserProfiler.model_json_schema(), cls=UUIDEncoder) + "'. "
+        )
+
+
+
+        user_profiler_tools = [retrieve_project_data_tool, save_project_data_tool]
+        delegate_tools = [transfer_back_to_triage_tool]
+
+        super().__init__(
+            description="A user profiler agent responsible for understanding the user's capabilities and knowledge.",
+            system_message=system_message,
+            model_client=model_client,
+            tools=user_profiler_tools + (tools or []),
+            delegate_tools=delegate_tools,
+            agent_topic_type=USER_PROFILER_AGENT_TOPIC_TYPE,
+            user_topic_type=USER_TOPIC_TYPE,
+        )

--- a/backend/models/data_models.py
+++ b/backend/models/data_models.py
@@ -78,7 +78,7 @@ linkml_meta = LinkMLMeta({'default_prefix': 'pm',
                            'prefix_reference': 'http://www.w3.org/ns/prov#'},
                   'schema': {'prefix_prefix': 'schema',
                              'prefix_reference': 'http://schema.org/'}},
-     'source_file': 'data_model_linkml_enhanced.yaml',
+     'source_file': 'data_model/data_model.yaml',
      'title': 'Enhanced Agile Project Management Data Model',
      'types': {'date': {'base': 'str',
                         'description': 'Date in YYYY-MM-DD format',
@@ -239,6 +239,16 @@ class RoleEnum(str, Enum):
     Project_Manager = "Project Manager"
     Business_Analyst = "Business Analyst"
     Sponsor = "Sponsor"
+
+
+class ExperienceLevelEnum(str, Enum):
+    """
+    Levels of experience for users
+    """
+    Beginner = "Beginner"
+    Intermediate = "Intermediate"
+    Advanced = "Advanced"
+    Expert = "Expert"
 
 
 class InfluenceLevelEnum(str, Enum):
@@ -2034,10 +2044,10 @@ class TeamMember(Person):
                                  'range': 'RoleEnum',
                                  'required': True}}})
 
-    role: RoleEnum = Field(default=..., description="""Primary role""", json_schema_extra = { "linkml_meta": {'alias': 'role', 'domain_of': ['TeamMember', 'Stakeholder']} })
+    role: RoleEnum = Field(default=..., description="""Primary role""", json_schema_extra = { "linkml_meta": {'alias': 'role', 'domain_of': ['TeamMember', 'Stakeholder', 'UserProfiler']} })
     capacity: Optional[float] = Field(default=None, description="""Weekly capacity in hours""", ge=0, json_schema_extra = { "linkml_meta": {'alias': 'capacity', 'domain_of': ['Team', 'TeamMember']} })
     is_active: Optional[bool] = Field(default=True, description="""Active status""", json_schema_extra = { "linkml_meta": {'alias': 'is_active', 'domain_of': ['TeamMember'], 'ifabsent': 'boolean(true)'} })
-    skills: Optional[list[str]] = Field(default=None, description="""Skills""", json_schema_extra = { "linkml_meta": {'alias': 'skills', 'domain_of': ['TeamMember']} })
+    skills: Optional[list[str]] = Field(default=None, description="""Skills""", json_schema_extra = { "linkml_meta": {'alias': 'skills', 'domain_of': ['TeamMember', 'UserProfiler']} })
     start_date: Optional[str] = Field(default=None, description="""Start date""", json_schema_extra = { "linkml_meta": {'alias': 'start_date', 'domain_of': ['Sprint', 'TeamMember', 'Phase']} })
     end_date: Optional[str] = Field(default=None, description="""End date""", json_schema_extra = { "linkml_meta": {'alias': 'end_date', 'domain_of': ['Sprint', 'TeamMember', 'Phase']} })
     id: str = Field(default=..., description="""Unique identifier""", json_schema_extra = { "linkml_meta": {'alias': 'id',
@@ -2076,13 +2086,13 @@ class Stakeholder(Person):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://example.org/software_project_management'})
 
-    role: Optional[RoleEnum] = Field(default=None, description="""Primary role""", json_schema_extra = { "linkml_meta": {'alias': 'role', 'domain_of': ['TeamMember', 'Stakeholder']} })
+    role: Optional[RoleEnum] = Field(default=None, description="""Primary role""", json_schema_extra = { "linkml_meta": {'alias': 'role', 'domain_of': ['TeamMember', 'Stakeholder', 'UserProfiler']} })
     influence: Optional[InfluenceLevelEnum] = Field(default=None, description="""Influence level""", json_schema_extra = { "linkml_meta": {'alias': 'influence', 'domain_of': ['Stakeholder']} })
     interest: Optional[InterestLevelEnum] = Field(default=None, description="""Interest level""", json_schema_extra = { "linkml_meta": {'alias': 'interest', 'domain_of': ['Stakeholder']} })
     communication_preferences: Optional[str] = Field(default=None, description="""Communication preferences""", json_schema_extra = { "linkml_meta": {'alias': 'communication_preferences', 'domain_of': ['Stakeholder', 'Person']} })
     engagement_plan: Optional[str] = Field(default=None, description="""Engagement plan""", json_schema_extra = { "linkml_meta": {'alias': 'engagement_plan', 'domain_of': ['Stakeholder']} })
     concerns: Optional[list[str]] = Field(default=None, description="""Concerns""", json_schema_extra = { "linkml_meta": {'alias': 'concerns', 'domain_of': ['Stakeholder']} })
-    expectations: Optional[list[str]] = Field(default=None, description="""Expectations""", json_schema_extra = { "linkml_meta": {'alias': 'expectations', 'domain_of': ['Stakeholder']} })
+    expectations: Optional[list[str]] = Field(default=None, description="""Expectations""", json_schema_extra = { "linkml_meta": {'alias': 'expectations', 'domain_of': ['Stakeholder', 'UserProfiler']} })
     id: str = Field(default=..., description="""Unique identifier""", json_schema_extra = { "linkml_meta": {'alias': 'id',
          'domain_of': ['Project',
                        'BusinessCase',
@@ -2110,6 +2120,46 @@ class Stakeholder(Person):
                        'AIWorkProduct']} })
     person_name: str = Field(default=..., description="""Person's name""", ge=1, le=100, json_schema_extra = { "linkml_meta": {'alias': 'person_name', 'domain_of': ['Person']} })
     email: Optional[str] = Field(default=None, description="""Contact email""", json_schema_extra = { "linkml_meta": {'alias': 'email', 'domain_of': ['Person']} })
+
+
+class UserProfiler(Person):
+    """
+    Represents a user's profile, including their skills, experience, and expectations.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://example.org/software_project_management'})
+
+    role: Optional[RoleEnum] = Field(default=None, description="""Primary role""", json_schema_extra = { "linkml_meta": {'alias': 'role', 'domain_of': ['TeamMember', 'Stakeholder', 'UserProfiler']} })
+    experience: Optional[ExperienceLevelEnum] = Field(default=None, description="""User's experience level""", json_schema_extra = { "linkml_meta": {'alias': 'experience', 'domain_of': ['UserProfiler']} })
+    skills: Optional[list[str]] = Field(default=None, description="""Skills""", json_schema_extra = { "linkml_meta": {'alias': 'skills', 'domain_of': ['TeamMember', 'UserProfiler']} })
+    expectations: Optional[list[str]] = Field(default=None, description="""Expectations""", json_schema_extra = { "linkml_meta": {'alias': 'expectations', 'domain_of': ['Stakeholder', 'UserProfiler']} })
+    id: str = Field(default=..., description="""Unique identifier""", json_schema_extra = { "linkml_meta": {'alias': 'id',
+         'domain_of': ['Project',
+                       'BusinessCase',
+                       'Requirement',
+                       'Epic',
+                       'UserStory',
+                       'Backlog',
+                       'BacklogItem',
+                       'Sprint',
+                       'Issue',
+                       'Team',
+                       'Risk',
+                       'Milestone',
+                       'Deliverable',
+                       'ChangeRequest',
+                       'Baseline',
+                       'TestCase',
+                       'Phase',
+                       'WorkStream',
+                       'Documentation',
+                       'Repository',
+                       'Metric',
+                       'Person',
+                       'CommunicationPlan',
+                       'AIWorkProduct']} })
+    person_name: str = Field(default=..., description="""Person's name""", ge=1, le=100, json_schema_extra = { "linkml_meta": {'alias': 'person_name', 'domain_of': ['Person']} })
+    email: Optional[str] = Field(default=None, description="""Contact email""", json_schema_extra = { "linkml_meta": {'alias': 'email', 'domain_of': ['Person']} })
+    communication_preferences: Optional[str] = Field(default=None, description="""Communication preferences""", json_schema_extra = { "linkml_meta": {'alias': 'communication_preferences', 'domain_of': ['Stakeholder', 'Person']} })
 
 
 class CommunicationPlan(ConfiguredBaseModel):
@@ -2251,6 +2301,7 @@ Metric.model_rebuild()
 Person.model_rebuild()
 TeamMember.model_rebuild()
 Stakeholder.model_rebuild()
+UserProfiler.model_rebuild()
 CommunicationPlan.model_rebuild()
 AIWorkProduct.model_rebuild()
 

--- a/data_model/data_model.yaml
+++ b/data_model/data_model.yaml
@@ -131,6 +131,13 @@ enums:
       "Project Manager":
       "Business Analyst":
       "Sponsor":
+  ExperienceLevelEnum:
+    description: Levels of experience for users
+    permissible_values:
+      Beginner:
+      Intermediate:
+      Advanced:
+      Expert:
   InfluenceLevelEnum:
     description: Levels of influence for stakeholders
     permissible_values:
@@ -611,6 +618,9 @@ slots:
     range: string
     multivalued: true
     description: Expectations
+  experience:
+    range: ExperienceLevelEnum
+    description: "User's experience level"
   triggers:
     range: string
     multivalued: true
@@ -980,6 +990,15 @@ classes:
       - communication_preferences
       - engagement_plan
       - concerns
+      - expectations
+
+  UserProfiler:
+    is_a: Person
+    description: "Represents a user's profile, including their skills, experience, and expectations."
+    slots:
+      - role
+      - experience
+      - skills
       - expectations
 
   Risk:


### PR DESCRIPTION
This commit introduces a new User Profiler Agent to the system.

The User Profiler Agent is responsible for understanding the user's capabilities and knowledge to better tune other agents' tone and questions based on its profile.

The changes in this commit include:
- A new `UserProfiler` class in the data model, inheriting from `Person`.
- An `ExperienceLevelEnum` to represent the user's experience level.
- A new `UserProfilerAgent` that asks the user about their role, experience, skills, and expectations.
- Integration of the new agent into the system's agent factory and triage agent.
- Updated documentation in `GEMINI.md` to reflect the new agent and data model management instructions.